### PR TITLE
Remove part about stack access performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,6 @@ nastavit jak při linkování, tak dynamicky syscallem, v Linuxu např. pomocí 
 [setrlimit](https://linux.die.net/man/2/setrlimit).
 </details>
 
-Přístup k proměnným na stacku je rychlý, protože k nim program přistupuje přímo -- ví, kde
-se paměť nachází a může k ní rovnou přistoupit.
-
 ### Využití paměti na stacku
 
 Proměnné jsou automaticky alokovány na stacku. Chceme-li tedy využít stack, stačí nám


### PR DESCRIPTION
This part is a bit misleading. The address of stack variables is not known at compilation time, stack can be located pretty much anywhere in the address space. Local variables are accessed in the same way as memory on the heap, using their addresses (or rather by something like `[RBP + X]`, but that's not inherently faster than e.g. `[EAX]`).

Using stack memory can indeed be faster, but for other reasons:
- Access patterns - due to its nature, stack accesses occur repeatedly within a small area of memory, so it can be effectively cached.
- Layout - due to its nature, the memory is placed close together, which again helps cached.
- Allocation - stack allocation/deallocation is super simple and fast.